### PR TITLE
Hide the sitekey

### DIFF
--- a/src/public/js/servers/vote.js
+++ b/src/public/js/servers/vote.js
@@ -11,6 +11,6 @@ async function submit(){
 
 var onloadCallback = function() {
     grecaptcha.render('html_element', {
-      'sitekey' : '6LfCmcQZAAAAAE0WHXmb9nqMgMQmUwmBmbV76BuU'
+      'sitekey' : 'your sitkey here'
     });
 };


### PR DESCRIPTION
The reCaptcha sitekey is exposed. This pull request will hide the site key preventing malicious use